### PR TITLE
Metrics transformer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
       organization := "me.andrusha",
       scalaVersion := "2.12.4",
       crossScalaVersions := Seq("2.12.4", "2.11.12"),
-      version      := "0.2.0-SNAPSHOT"
+      version      := "0.2.0"
     )),
     name := "Dropwizard Prometheus",
     description := "Dropwizard metrics exporter in Prometheus format",

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).
       organization := "me.andrusha",
       scalaVersion := "2.12.4",
       crossScalaVersions := Seq("2.12.4", "2.11.12"),
-      version      := "0.1.1"
+      version      := "0.2.0-SNAPSHOT"
     )),
     name := "Dropwizard Prometheus",
     description := "Dropwizard metrics exporter in Prometheus format",

--- a/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Dimensions.scala
+++ b/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Dimensions.scala
@@ -1,10 +1,19 @@
 package me.andrusha.dropwizardprometheus.metrics
 
 case class Dimensions(d: Map[String, String]) extends AnyVal {
+  /**
+    * https://prometheus.io/docs/concepts/data_model
+    * @todo escape values, verify that keys are correct
+    * @return prometheus-compatible dimension string
+    */
   def toPrometheus: String = {
     d.map { case (k, v) => s"""$k="$v"""" }.mkString("{", ",", "}")
   }
 
+  /**
+    * @todo allow to merge with Dimensions object
+    * @return merged dimensions, other has precedence
+    */
   def merge(other: Map[String, String]): Dimensions =
     Dimensions(other.foldLeft(d) { case (m, (k, v)) => m.updated(k, v) })
 }

--- a/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Dimensions.scala
+++ b/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Dimensions.scala
@@ -5,9 +5,8 @@ case class Dimensions(d: Map[String, String]) extends AnyVal {
     d.map { case (k, v) => s"""$k="$v"""" }.mkString("{", ",", "}")
   }
 
-  def append(k: String, v: String): Dimensions = {
-    Dimensions(d.updated(k, v))
-  }
+  def merge(other: Map[String, String]): Dimensions =
+    Dimensions(other.foldLeft(d) { case (m, (k, v)) => m.updated(k, v) })
 }
 
 object Dimensions {

--- a/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Metric.scala
+++ b/src/main/scala/me/andrusha/dropwizardprometheus/metrics/Metric.scala
@@ -26,6 +26,11 @@ object Metric {
     }
   }
 
+  /**
+    * https://prometheus.io/docs/concepts/data_model
+    * @param name to be converted
+    * @return metric name converted to Prometheus format
+    */
   def nameToPrometheus(name: String): String = {
     name.split('.').map(NameCase.toSnakeCase).mkString(":")
   }

--- a/src/main/scala/me/andrusha/dropwizardprometheus/metrics/SampledMetric.scala
+++ b/src/main/scala/me/andrusha/dropwizardprometheus/metrics/SampledMetric.scala
@@ -25,7 +25,7 @@ case class SampledMetric(
     dimensions: Dimensions = Dimensions.Empty) extends Metric {
   override def toPrometheus: String = {
     val s = samples.map { s =>
-      val d = dimensions.append("quantile", s.quantile)
+      val d = dimensions.merge(Map("quantile" -> s.quantile))
       s"""$name${d.toPrometheus} ${s.value}"""
     }.mkString("\n")
 

--- a/src/test/scala/me/andrusha/dropwizardprometheus/metrics/DimensionsTest.scala
+++ b/src/test/scala/me/andrusha/dropwizardprometheus/metrics/DimensionsTest.scala
@@ -1,0 +1,21 @@
+package me.andrusha.dropwizardprometheus.metrics
+
+import org.scalatest.FunSpec
+
+class DimensionsTest extends FunSpec {
+  describe("toPrometheus") {
+    it("joins dimensions in prometheus format") {
+      val d = Dimensions(Map("cat" -> "dog", "mouse" -> "cat"))
+      assert(d.toPrometheus == """{cat="dog",mouse="cat"}""")
+    }
+  }
+
+  describe("merge") {
+    it("joins dimensions together") {
+      val d1 = Dimensions(Map("cat" -> "dog", "conflict" -> "old"))
+      val d2 = Dimensions(Map("mouse" -> "cat", "conflict" -> "new"))
+
+      assert(d1.merge(d2.d) == Dimensions(Map("cat" -> "dog", "mouse" -> "cat", "conflict" -> "new")))
+    }
+  }
+}

--- a/src/test/scala/me/andrusha/dropwizardprometheus/metrics/MetricTest.scala
+++ b/src/test/scala/me/andrusha/dropwizardprometheus/metrics/MetricTest.scala
@@ -1,0 +1,9 @@
+package me.andrusha.dropwizardprometheus.metrics
+
+class MetricTest extends org.scalatest.FunSpec {
+  describe("nameToPrometheus") {
+    it("converts to snake_case terms split on dot") {
+      assert(Metric.nameToPrometheus("camelCase.kebab-case.snake_case") == "camel_case:kebab_case:snake_case")
+    }
+  }
+}


### PR DESCRIPTION
Expose metrics transformation before the export in order to allow user to modify names/dimensions. Closes #1 